### PR TITLE
Layout fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-- 2.1
+- 2.2
 install: gem install jekyll
 script: "[ -e _config_${TRAVIS_BRANCH}.yml ] && jekyll build --config _config_${TRAVIS_BRANCH}.yml || jekyll build"
 branches:

--- a/_data/assets.yml
+++ b/_data/assets.yml
@@ -1,0 +1,50 @@
+- name: In Copyright
+  buttons:
+    - InC.dark-white-interior-blue-type.svg
+    - InC-OW-EU.dark-white-interior-blue-type.svg
+    - InC-EDU.dark-white-interior-blue-type.svg
+    - InC-NC.dark-white-interior-blue-type.svg
+    - InC-RUU.dark-white-interior-blue-type.svg
+    - InC.dark-white-interior.svg
+    - InC-OW-EU.dark-white-interior.svg
+    - InC-EDU.dark-white-interior.svg
+    - InC-NC.dark-white-interior.svg
+    - InC-RUU.dark-white-interior.svg
+    - InC.dark.svg
+    - InC-OW-EU.dark.svg
+    - InC-EDU.dark.svg
+    - InC-NC.dark.svg
+    - InC-RUU.dark.svg
+    - InC.white.svg
+    - InC-OW-EU.white.svg
+    - InC-EDU.white.svg
+    - InC-NC.white.svg
+    - InC-RUU.white.svg
+- name: No Copyright
+  buttons:
+    - NoC-CR.dark-white-interior-blue-type.svg
+    - NoC-NC.dark-white-interior-blue-type.svg
+    - NoC-OKLR.dark-white-interior-blue-type.svg
+    - NoC-US.dark-white-interior-blue-type.svg
+    - NoC-CR.dark-white-interior.svg
+    - NoC-NC.dark-white-interior.svg
+    - NoC-OKLR.dark-white-interior.svg
+    - NoC-US.dark-white-interior.svg
+    - NoC-CR.dark.svg
+    - NoC-NC.dark.svg
+    - NoC-OKLR.dark.svg
+    - NoC-US.dark.svg
+    - NoC-CR.white.svg
+    - NoC-NC.white.svg
+    - NoC-OKLR.white.svg
+    - NoC-US.white.svg
+- name: Other
+  buttons:
+    - CNE.dark-white-interior-blue-type.svg
+    - NKC.dark-white-interior-blue-type.svg
+    - CNE.dark-white-interior.svg
+    - NKC.dark-white-interior.svg
+    - CNE.dark.svg
+    - NKC.dark.svg
+    - CNE.white.svg
+    - NKC.white.svg

--- a/_data/slides.yml
+++ b/_data/slides.yml
@@ -3,10 +3,16 @@
   title: <a href="http://dp.la/item/c5b87d8f1cc44cc2765345ccafbb7a5b">Mt. Mitchell Station, Mt. Mitchell, N.C.</a>
   desc:
     <h2>RightsStatements.org provides 11 standardized rights statements for online cultural heritage.</h2>
-    <p>Our rights statements make it easy to see if and how online cultural heritage works can be reused.</p>
+    <p>
+      Our rights statements make it easy to see if and how online cultural heritage works can be reused.
+      Find out more about our statements <a href="rights_app_server/vocab/rights_data_version/">here</a>.
+    </p>
 - image: slide-2.jpg
   desc_location: left
   title: <a href="http://www.europeana.eu/portal/record/2020601/attachments_149982_6103_149982_original_149982_jpg.html#">Postcard from Vienna (Luigi Meula) CC-BY-SA</a>
   desc:
     <h2>RightsStatements.org provides 11 standardized rights statements for online cultural heritage.</h2>
-    <p>Our rights statements make it easy to see if and how online cultural heritage works can be reused.</p>
+    <p>
+      Our rights statements make it easy to see if and how online cultural heritage works can be reused.
+      Find out more about our statements <a href="rights_app_server/vocab/rights_data_version/">here</a>.
+    </p>

--- a/_includes/collection.html
+++ b/_includes/collection.html
@@ -6,7 +6,7 @@
         <div class="row">
           <div class="large-4 columns">
             <div class="statement-iconcolumn">
-              <img src="{{ site.url }}{{ site.baseurl }}/files/icons/{{ identifier }}.white.svg" title="{{ prefLabel.[@value] }}" />
+              <img src="{% endraw %}{{ site.url }}{{ site.baseurl }}{% raw %}/files/icons/{{ identifier }}.white.svg" title="{{ prefLabel.[@value] }}" />
             </div>
           </div>
           <div class="large-8 columns">

--- a/_includes/collection.html
+++ b/_includes/collection.html
@@ -6,7 +6,7 @@
         <div class="row">
           <div class="large-4 columns">
             <div class="statement-iconcolumn">
-              <img src="/files/icons/{{ identifier }}.white.svg" title="{{ prefLabel.[@value] }}" />
+              <img src="{{ site.url }}{{ site.baseurl }}/files/icons/{{ identifier }}.white.svg" title="{{ prefLabel.[@value] }}" />
             </div>
           </div>
           <div class="large-8 columns">

--- a/_includes/slider.html
+++ b/_includes/slider.html
@@ -7,8 +7,7 @@
         </div>
         <div class='orbit-caption caption-{{ slide.desc_location }}'>
           <div class='row rounded-corners'>
-            {{ slide.desc }}
-            <p>Find out more about our statements <a href="{{ site.rights_app_server }}/vocab/{{ site.rights_data_version }}/">here</a>.</p>
+            {{ slide.desc | replace: 'rights_app_server', site.rights_app_server | replace: 'rights_data_version', site.rights_data_version }}
           </div>
         </div>
         <div class="caption"><div class="row text-right">{{ slide.title }}</div></div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,7 +16,7 @@
       <link href='{{ site.url }}{{ site.baseurl }}/css/syntax.css' rel='stylesheet'>
       <link href='{{ site.url }}{{ site.baseurl }}/css/style.css' rel='stylesheet'>
       <link href='{{ site.url }}{{ site.baseurl }}/css/fontello.css' rel='stylesheet'>
-      <link href='{{ site.url }}{{ site.baseurl }}/css/rs.css' rel='stylesheet'>
+      <link href='http://graphthinking.com/etherpad2css.php?pad=rights-site.css' rel='stylesheet'>
 
       <link rel="stylesheet" type="text/css" href="//cloud.typography.com/7018914/6677352/css/fonts.css" />
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,7 +16,7 @@
       <link href='{{ site.url }}{{ site.baseurl }}/css/syntax.css' rel='stylesheet'>
       <link href='{{ site.url }}{{ site.baseurl }}/css/style.css' rel='stylesheet'>
       <link href='{{ site.url }}{{ site.baseurl }}/css/fontello.css' rel='stylesheet'>
-      <link href='http://graphthinking.com/etherpad2css.php?pad=rights-site.css' rel='stylesheet'>
+      <link href='{{ site.url }}{{ site.baseurl }}/css/rights-site.css' rel='stylesheet'>
 
       <link rel="stylesheet" type="text/css" href="//cloud.typography.com/7018914/6677352/css/fonts.css" />
 
@@ -90,7 +90,7 @@
 
 	      <div class="row">
 		      <div class="negative-margin">
-						<div class="large-8 columns">
+						<div class="small-8 columns">
 							<p>
 								RightsStatements.org is a project of <a href="http://dp.la">DPLA</a> and <a href="http://www.europeana.eu">Europeana</a>
 							</p>
@@ -98,7 +98,7 @@
 								Except where otherwise noted, content on this site is licensed under a <a href="https://creativecommons.org/publicdomain/zero/1.0/">CC0 Public Domain Dedication</a>.
 							</p>
 						</div>
-						<div class="large-4 columns">
+						<div class="small-4 columns">
 							<ul class="right footer-nav">
 <!--
 								<li><a href="#">Terms of Use</a></li>

--- a/_layouts/front.html
+++ b/_layouts/front.html
@@ -5,7 +5,7 @@ layout: default
 {% include slider.html %}
 
 <div class="full home rounded-corners">
-	<div class='row'>
+	<div class='row column'>
   	{{ content }}
 	</div>
 </div>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -4,7 +4,7 @@ layout: default
 
 <div class="bg-white-top-left">
 	<div class="full rounded-corners">
-		<div class='row'>
+		<div class='row column'>
 		  {{ content }}
 		</div>
 	</div>

--- a/css/framework.css
+++ b/css/framework.css
@@ -4820,8 +4820,8 @@ table tfoot tr td {
   }
 }
 meta.foundation-mq-topbar {
-  font-family: "/only screen and (min-width:40.063em)/";
-  width: 40.063em;
+  font-family: "/only screen and (min-width:60em)/";
+  width: 60em;
 }
 
 /* Wrapped around .top-bar to contain to grid width */
@@ -5187,7 +5187,8 @@ meta.foundation-mq-topbar {
   display: block;
 }
 
-@media only screen and (min-width: 40.063em) {
+/* @media only screen and (min-width: 40.063em) { */
+@media only screen and (min-width: 60em) {
   .top-bar {
     background: white;
     *zoom: 1;

--- a/css/rights-site.css
+++ b/css/rights-site.css
@@ -407,10 +407,28 @@ small,
 }
 
 .statement-iconcolumn > img {
-  width: 100%;
   height: 50px;
 }
 
 .statement-box a {
   word-wrap: break-word;
+}
+
+/* --- buttons and other assets --- */
+
+.statement-button {
+  background-color: #f1f2f2;
+  margin: 20px;
+  padding: 20px;
+}
+
+.statement-button h4 {
+  padding-top: 20px;
+  margin-bottom: 0px;
+  text-align: left;
+  color: #858589;
+}
+
+.statement-button img {
+  height: 50px;
 }

--- a/css/rights-site.css
+++ b/css/rights-site.css
@@ -170,11 +170,6 @@ small,
   z-index: 9;
 }
 
-@media only screen and (min-width: 60em) {
-  .top-bar-section ul li.active > a:after
-    background: #FFFFFF !important;
-  }
-}
 
 .top-bar-section ul li.active > a:after {
   content: '';
@@ -221,6 +216,12 @@ small,
   line-height: 50px;
 }
 
+:target:before {
+  content: "";
+  display: block;
+  height: 140px;
+  margin: -140px 0 0;
+}
 
 /* --- slide show --- */
 

--- a/css/rights-site.css
+++ b/css/rights-site.css
@@ -170,6 +170,12 @@ small,
   z-index: 9;
 }
 
+@media only screen and (min-width: 60em) {
+  .top-bar-section ul li.active > a:after
+    background: #FFFFFF !important;
+  }
+}
+
 .top-bar-section ul li.active > a:after {
   content: '';
   background: #008CC8;
@@ -245,6 +251,13 @@ small,
 	}
 }
 
+@media screen and (max-width: 480px) {
+
+	.orbit-container {
+		display: none;
+	}
+}
+
 .orbit-container {
   background: white;
 }
@@ -309,7 +322,7 @@ small,
   background: #f1f2f2;
 }
 
-@media screen and (max-width: 480px) {
+@media only screen and (max-width: 60em) {
   .box {
     margin: 20px -50px;
   }

--- a/css/rights-site.css
+++ b/css/rights-site.css
@@ -71,6 +71,12 @@ small,
   color: #555555;
 }
 
+@media screen and (max-width: 480px) {
+  h1, h2, h3, h4, h5, h6 {
+    font-size: 16px;
+  }
+}
+
 /* --- container --- */
 
 .full {

--- a/css/rights-site.css
+++ b/css/rights-site.css
@@ -373,6 +373,7 @@ small,
 .statements-category-teaser h3 {
   color: #318ac7;
   margin-bottom: 25px;
+  white-space: nowrap;
 }
 
 .statements-category-teaser p {

--- a/css/rights-site.css
+++ b/css/rights-site.css
@@ -404,3 +404,7 @@ small,
   width: 100%;
   height: 50px;
 }
+
+.statement-box a {
+  word-wrap: break-word;
+}

--- a/css/rights-site.css
+++ b/css/rights-site.css
@@ -2,15 +2,16 @@
 
 body {
   background: #858589;
-  font-size: 18px;
-  line-height: 1.4;
+  font-size: 16px;
+  line-height: 1.5;
+  overflow-x: hidden;
 }
 
 body,
 h1, h2, h3, h4, h5, h6,
 .top-bar-section ul li > a {
-	font-family: "Gotham SSm A", "Gotham SSm B";
-	color: #414042;
+        font-family: "Gotham SSm A", "Gotham SSm B";
+        color: #414042;
 }
 
 h1, h2, h3, h4, h5, h6 {
@@ -19,15 +20,19 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 h1 {
+-webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
   font-size: 32px;
   margin-top: 1.5em;
 }
 
 h2 {
-	font-size: 32px;
-	font-weight: 200;
-	margin-top: 1.8em;
-	text-transform: none;
+-webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+        font-size: 34px;
+        font-weight: 200;
+        margin-top: 1.8em;
+        text-transform: none;
 }
 
 h3 {
@@ -46,9 +51,9 @@ a {
 }
 
 p {
-  font-size: 18px;
+  font-size: 16px;
   font-weight: 300;
-  line-height: 1.4;
+  line-height: 1.5;
 }
 
 p:last-child {
@@ -90,6 +95,7 @@ small,
 .full.home {
   background: white;
   border-top-left-radius: 0px;
+  padding-top: 0px;
 }
 
 .bg-white {
@@ -107,6 +113,15 @@ small,
   margin: 0 -15px;
 }
 
+@media screen and (max-width: 1160px) {
+	.negative-margin {
+	  margin: 0 0;
+	}
+}
+
+.row.column {
+	float: none;
+}
 
 /* --- header --- */
 
@@ -127,6 +142,13 @@ small,
 }
 .top-bar .name h1 {
   width: 355px;
+  padding-left: 20px;
+}
+
+@media screen and (max-width: 480px) {
+	.top-bar .name h1 {
+		width: 250px;
+	}
 }
 
 .top-bar .name h1 a {
@@ -197,9 +219,30 @@ small,
 /* --- slide show --- */
 
 @media screen and (max-width: 932px) {
+/*
   .orbit-container {
     display: none;
   }
+*/
+
+	.orbit-container p {
+		font-size: 13px !important;
+	}
+
+	.orbit-caption h2 {
+	  font-size: 18px !important;
+	}
+
+	.orbit-container .orbit-slides-container li .orbit-caption {
+		top: 20px;
+	}
+}
+
+@media screen and (max-width: 720px) {
+
+	.orbit-caption {
+		display: none;
+	}
 }
 
 .orbit-container {
@@ -229,7 +272,8 @@ small,
 }
 
 .orbit-slides-container .caption {
-  position: relative
+  position: relative;
+  margin-right: 20px;
 }
 
 
@@ -254,7 +298,7 @@ small,
   border-top-left-radius: 30px;
   border-bottom-right-radius: 30px;
   padding: 40px 50px;
-  margin: 60px 0;
+  margin: 60px -50px;
 }
 
 .box h1:first-child, .box h2:first-child, .box h3:first-child, .box h4:first-child, .box h5:first-child, .box h6:first-child {
@@ -263,6 +307,19 @@ small,
 
 .full.home .box {
   background: #f1f2f2;
+}
+
+@media screen and (max-width: 480px) {
+  .box {
+    margin: 20px -50px;
+  }
+  .full {
+    padding: 10px;
+  }
+  .rounded-corners {
+    border-top-left-radius: 0px;
+    border-bottom-right-radius: 0px;
+  }
 }
 
 

--- a/css/rights-stmt.css
+++ b/css/rights-stmt.css
@@ -31,10 +31,11 @@ body {
   background: -webkit-linear-gradient(top,  #c6c5c6 0%,#c6c5c6 46%,#737b88 100%);
   background: linear-gradient(to bottom,  #c6c5c6 0%,#c6c5c6 46%,#737b88 100%);
   filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#c6c5c6', endColorstr='#737b88',GradientType=0 );
+  overflow-x: hidden;
 }
 
 .row {
-  background-color: white;
+/*   background-color: white; */
 }
 
 body, li > span {
@@ -61,7 +62,7 @@ ol, ul {
 li {
   margin-bottom: 1rem;
 }
- 
+
 .row.footer {
   background-color: #f8f8f8;
 }
@@ -87,9 +88,17 @@ html, body {
 }
 
 .statement-container {
-  margin-top: 2em;
-  margin-bottom: 4em;
+	padding: 2em 2em 4em 2em;
+}
+
+
+.statement-wrapper {
+  background: white;
   box-shadow: 0 30px 50px rgba(0,0,0,0.2);
+}
+
+.statement-wrapper .row {
+	margin: 0;
 }
 
 .statement-main {
@@ -120,4 +129,17 @@ html, body {
 .statement-iconcolumn > img {
   width: 100%;
   height: 60px;
+}
+
+
+
+@media screen and (max-width: 450px) {
+
+	.statement-container {
+		padding: 0em;
+	}
+
+	.statement-main {
+	  padding-top: 0em;
+	}
 }

--- a/en/404.json
+++ b/en/404.json
@@ -1,0 +1,3 @@
+{
+  "message": "Not Found"
+}

--- a/en/404.md
+++ b/en/404.md
@@ -1,0 +1,6 @@
+---
+layout: page
+title: Not Found
+---
+
+# Not Found

--- a/en/406.json
+++ b/en/406.json
@@ -1,0 +1,3 @@
+{
+  "message": "Not Acceptable"
+}

--- a/en/406.md
+++ b/en/406.md
@@ -1,0 +1,6 @@
+---
+layout: page
+title: Not Acceptable
+---
+
+# Not Acceptable

--- a/en/documentation/assets.md
+++ b/en/documentation/assets.md
@@ -10,25 +10,27 @@ Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula 
 
 ## Buttons
 
-<div class="box row" markdown="0">
-
-{% for member in site.data.assets %}
-
-<div class="medium-4 columns">
+<div class="box" markdown="0">
   <div class="row">
-    <h3>{{ member.name }}</h3>
-  </div>
-  {% for button in member.buttons %}
-  <div class="row">
-    <div class="statement-button">
-      <img src="{{ site.url }}{{ site.baseurl }}/files/icons/{{ button }}" />
-      <h4>Download</h4>
-      <a href="{{ site.url }}{{ site.baseurl }}/files/icons/{{ button }}">SVG</a>
+  
+  {% for member in site.data.assets %}
+  
+    <div class="medium-4 columns">
+      <div class="row">
+        <h3>{{ member.name }}</h3>
+      </div>
+      {% for button in member.buttons %}
+      <div class="row">
+        <div class="statement-button">
+          <img src="{{ site.url }}{{ site.baseurl }}/files/icons/{{ button }}" />
+          <h4>Download</h4>
+          <a href="{{ site.url }}{{ site.baseurl }}/files/icons/{{ button }}">SVG</a>
+        </div>
+      </div>
+      {% endfor %}
     </div>
-  </div>
+  
   {% endfor %}
-</div>
-
-{% endfor %}
-
+  
+  </div>
 </div>

--- a/en/documentation/assets.md
+++ b/en/documentation/assets.md
@@ -8,10 +8,27 @@ section_id: documentation
 
 Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
 
-Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo.
+## Buttons
 
-Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus.
+<div class="box row" markdown="0">
 
-Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus.
+{% for member in site.data.assets %}
 
-Maecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. Sed consequat, leo eget bibendum sodales, augue velit cursus nunc.
+<div class="medium-4 columns">
+  <div class="row">
+    <h3>{{ member.name }}</h3>
+  </div>
+  {% for button in member.buttons %}
+  <div class="row">
+    <div class="statement-button">
+      <img src="{{ site.url }}{{ site.baseurl }}/files/icons/{{ button }}" />
+      <h4>Download</h4>
+      <a href="{{ site.url }}{{ site.baseurl }}/files/icons/{{ button }}">SVG</a>
+    </div>
+  </div>
+  {% endfor %}
+</div>
+
+{% endfor %}
+
+</div>

--- a/en/statement.hbs
+++ b/en/statement.hbs
@@ -25,7 +25,7 @@
         <div class="row statement-main">
             <div class="large-4 columns">
                 <div class="statement-iconcolumn">
-                    <img src="{{ site.url }}{{ site.baseurl }}/files/icons/{{ data.identifier }}.white.svg" title="{{ data.prefLabel.[@value] }}" />
+                    <img src="{% endraw %}{{ site.url }}{{ site.baseurl }}{% raw %}/files/icons/{{ data.identifier }}.white.svg" title="{{ data.prefLabel.[@value] }}" />
                 </div>
             </div>
             <div class="large-8 columns">
@@ -55,7 +55,7 @@
                 {{{ i18n "provider" locale=language }}}
             </div>
             <div class="large-3 columns">
-                <img src="{{ site.url }}{{ site.baseurl }}/files/images/logo.svg" />
+                <img src="{% endraw %}{{ site.url }}{{ site.baseurl }}{% raw %}/files/images/logo.svg" />
             </div>
         </div>
     </div>

--- a/en/statement.hbs
+++ b/en/statement.hbs
@@ -10,7 +10,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Rights Statements</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/foundation/6.2.0/foundation.min.css" />
-    <link href='{{ site.url }}{{ site.baseurl }}/css/stmt.css' rel='stylesheet'>
+    <link href='http://graphthinking.com/etherpad2css.php?pad=rights-stmt.css' rel='stylesheet'>
     <link rel="stylesheet" type="text/css" href="//cloud.typography.com/7018914/6677352/css/fonts.css" />
 </head>
 

--- a/en/statement.hbs
+++ b/en/statement.hbs
@@ -10,7 +10,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Rights Statements</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/foundation/6.2.0/foundation.min.css" />
-    <link href='http://graphthinking.com/etherpad2css.php?pad=rights-stmt.css' rel='stylesheet'>
+    <link href='{{ site.url }}{{ site.baseurl }}/css/rights-stmt.css' rel='stylesheet'>
     <link rel="stylesheet" type="text/css" href="//cloud.typography.com/7018914/6677352/css/fonts.css" />
 </head>
 
@@ -22,40 +22,42 @@
     </script>
 
     <div class="row columns statement-container">
-        <div class="row statement-main">
-            <div class="large-4 columns">
-                <div class="statement-iconcolumn">
-                    <img src="{% endraw %}{{ site.url }}{{ site.baseurl }}{% raw %}/files/icons/{{ data.identifier }}.white.svg" title="{{ data.prefLabel.[@value] }}" />
+        <div class="statement-wrapper">
+            <div class="row statement-main">
+                <div class="large-4 columns">
+                    <div class="statement-iconcolumn">
+                        <img src="{% endraw %}{{ site.url }}{{ site.baseurl }}{% raw %}/files/icons/{{ data.identifier }}.white.svg" title="{{ data.prefLabel.[@value] }}" />
+                    </div>
+                </div>
+                <div class="large-8 columns">
+                    <div class="statement-textcolumn">
+                        <h1>{{ data.prefLabel.[@value] }}</h1>
+                        <p>{{ data.definition.[@value] }}</p>
+                        {{#parameters.date}}
+                            <p>{{i18n data.identifier . locale=language}}</p>
+                        {{/parameters.date}}
+
+                        {{#parameters.relatedURL}}
+                            <p>{{{i18n data.identifier . locale=language}}}</p>
+                        {{/parameters.relatedURL}}
+                        <h2>{{i18n "notices" locale=language}}</h2>
+                        <ul>
+                            {{#sort data.note direction="asc"}}
+                                <li><span>{{ [@value] }}</span></li>
+                            {{/sort}}
+                        </ul>
+                        <p class="disclaimer">{{{i18n "Disclaimer" locale=language}}}</p>
+                    </div>
                 </div>
             </div>
-            <div class="large-8 columns">
-                <div class="statement-textcolumn">
-                    <h1>{{ data.prefLabel.[@value] }}</h1>
-                    <p>{{ data.definition.[@value] }}</p>
-                    {{#parameters.date}}
-                        <p>{{i18n data.identifier . locale=language}}</p>
-                    {{/parameters.date}}
 
-                    {{#parameters.relatedURL}}
-                        <p>{{{i18n data.identifier . locale=language}}}</p>
-                    {{/parameters.relatedURL}}
-                    <h2>{{i18n "notices" locale=language}}</h2>
-                    <ul>
-                        {{#sort data.note direction="asc"}}
-                            <li><span>{{ [@value] }}</span></li>
-                        {{/sort}}
-                    </ul>
-                    <p class="disclaimer">{{{i18n "Disclaimer" locale=language}}}</p>
+            <div class="row footer">
+                <div class="large-9 columns">
+                    {{{ i18n "provider" locale=language }}}
                 </div>
-            </div>
-        </div>
-
-        <div class="row footer">
-            <div class="large-9 columns">
-                {{{ i18n "provider" locale=language }}}
-            </div>
-            <div class="large-3 columns">
-                <img src="{% endraw %}{{ site.url }}{{ site.baseurl }}{% raw %}/files/images/logo.svg" />
+                <div class="large-3 columns">
+                    <img src="{% endraw %}{{ site.url }}{{ site.baseurl }}{% raw %}/files/images/logo.svg" />
+                </div>
             </div>
         </div>
     </div>

--- a/en/statement.hbs
+++ b/en/statement.hbs
@@ -25,7 +25,7 @@
         <div class="row statement-main">
             <div class="large-4 columns">
                 <div class="statement-iconcolumn">
-                    <img src="/files/icons/{{ data.identifier }}.white.svg" title="{{ data.prefLabel.[@value] }}" />
+                    <img src="{{ site.url }}{{ site.baseurl }}/files/icons/{{ data.identifier }}.white.svg" title="{{ data.prefLabel.[@value] }}" />
                 </div>
             </div>
             <div class="large-8 columns">
@@ -55,7 +55,7 @@
                 {{{ i18n "provider" locale=language }}}
             </div>
             <div class="large-3 columns">
-                <img src="/files/images/logo.svg" />
+                <img src="{{ site.url }}{{ site.baseurl }}/files/images/logo.svg" />
             </div>
         </div>
     </div>

--- a/en/statements/index.md
+++ b/en/statements/index.md
@@ -43,7 +43,7 @@ The rights statements have been specifically developed for the needs of cultural
     </div>
   </div>
 </div>
-<div class="row">
+<div>
   <p>The rights statements fall in three categories: Statements for works that are in copyright, statements for works that are not in copyright and statements for works where the copyright status is unclear. The statements provide end users with easy to understand high level information about the copyright and re-use status of digital objects. With the exception of the two statements for objects with an unclear copyright status, these statements should only be applied after the copyright status of a work has been established. You can find more information about how to apply the rights statements in the [documentation section](/en/documentation).</p>
 </div>
 

--- a/en/statements/index.md
+++ b/en/statements/index.md
@@ -15,7 +15,7 @@ The rights statements have been specifically developed for the needs of cultural
 ## Three Categories of Rights Statements
 
 <div class="row" markdown="0">
-  <div class="large-4 columns">
+  <div class="medium-4 columns">
     <div class="statements-category-teaser">
       <a href="#rights-statements-for-in-copyright-objects"><h3>In Copyright</h3></a>
       <a href="#rights-statements-for-in-copyright-objects">
@@ -24,7 +24,7 @@ The rights statements have been specifically developed for the needs of cultural
       <p>Statements for works that are in copyright</p>
     </div>
   </div>
-  <div class="large-4 columns">
+  <div class="medium-4 columns">
     <div class="statements-category-teaser">
       <a href="#rights-statements-for-objects-that-are-not-in-copyright"><h3>No Copyright</h3></a>
       <a href="#rights-statements-for-objects-that-are-not-in-copyright">
@@ -33,7 +33,7 @@ The rights statements have been specifically developed for the needs of cultural
       <p>Statements for works that are not in copyright</p>
     </div>
   </div>
-  <div class="large-4 columns">
+  <div class="medium-4 columns">
     <div class="statements-category-teaser">
       <a href="#other-rights-statements"><h3>Other</h3></a>
       <a href="#other-rights-statements">

--- a/en/statements/index.md
+++ b/en/statements/index.md
@@ -17,23 +17,29 @@ The rights statements have been specifically developed for the needs of cultural
 <div class="row" markdown="0">
   <div class="large-4 columns">
     <div class="statements-category-teaser">
-       <h3>In Copyright</h3>
-       <img src="{{ site.url }}{{ site.baseurl }}/files/icons/InC.Icon-Only.dark.svg" />
-       <p>Statements for works that are in copyright</p>
+      <a href="#rights-statements-for-in-copyright-objects"><h3>In Copyright</h3></a>
+      <a href="#rights-statements-for-in-copyright-objects">
+        <img src="{{ site.url }}{{ site.baseurl }}/files/icons/InC.Icon-Only.dark.svg" />
+      </a>
+      <p>Statements for works that are in copyright</p>
     </div>
   </div>
   <div class="large-4 columns">
     <div class="statements-category-teaser">
-       <h3>No Copyright</h3>
-       <img src="{{ site.url }}{{ site.baseurl }}/files/icons/NoC.Icon-Only.dark.svg" />
-       <p>Statements for works that are not in copyright</p>
+      <a href="#rights-statements-for-objects-that-are-not-in-copyright"><h3>No Copyright</h3></a>
+      <a href="#rights-statements-for-objects-that-are-not-in-copyright">
+        <img src="{{ site.url }}{{ site.baseurl }}/files/icons/NoC.Icon-Only.dark.svg" />
+      </a>
+      <p>Statements for works that are not in copyright</p>
     </div>
   </div>
   <div class="large-4 columns">
     <div class="statements-category-teaser">
-       <h3>Other</h3>
-       <img src="{{ site.url }}{{ site.baseurl }}/files/icons/Other.Icon-Only.dark.svg" />
-       <p>Statements for works where the copyright status is unclear</p>
+      <a href="#other-rights-statements"><h3>Other</h3></a>
+      <a href="#other-rights-statements">
+        <img src="{{ site.url }}{{ site.baseurl }}/files/icons/Other.Icon-Only.dark.svg" />
+      </a>
+      <p>Statements for works where the copyright status is unclear</p>
     </div>
   </div>
 </div>

--- a/en/statements/index.md
+++ b/en/statements/index.md
@@ -5,7 +5,7 @@ section_id: statements
 alias: /vocab/
 ---
 
-# Rights statements 
+# Rights statements
 
 RightsStatements.org currently provides 11 different rights statements that can be used by cultural heritage institutions to communicate the copyright and re-use status of digital objects to the public. The rights statements have been designed with both human users and machine users (such as search engines) in mind and are made available as linked data. Each rights statement is located at a unique URI.
 
@@ -18,21 +18,21 @@ The rights statements have been specifically developed for the needs of cultural
   <div class="large-4 columns">
     <div class="statements-category-teaser">
        <h3>In Copyright</h3>
-       <img src="/files/icons/InC.Icon-Only.dark.svg" />
+       <img src="{{ site.url }}{{ site.baseurl }}/files/icons/InC.Icon-Only.dark.svg" />
        <p>Statements for works that are in copyright</p>
     </div>
   </div>
   <div class="large-4 columns">
     <div class="statements-category-teaser">
        <h3>No Copyright</h3>
-       <img src="/files/icons/NoC.Icon-Only.dark.svg" />
+       <img src="{{ site.url }}{{ site.baseurl }}/files/icons/NoC.Icon-Only.dark.svg" />
        <p>Statements for works that are not in copyright</p>
     </div>
   </div>
   <div class="large-4 columns">
     <div class="statements-category-teaser">
        <h3>Other</h3>
-       <img src="/files/icons/Other.Icon-Only.dark.svg" />
+       <img src="{{ site.url }}{{ site.baseurl }}/files/icons/Other.Icon-Only.dark.svg" />
        <p>Statements for works where the copyright status is unclear</p>
     </div>
   </div>
@@ -43,7 +43,7 @@ The rights statements have been specifically developed for the needs of cultural
 
 </div>
 
-## Rights statements for in copyright objects 
+## Rights statements for in copyright objects
 
 The following five rights statements are intended for use with digital objects that are in copyright. If your organization is the rightsholder for such objects and wants to encourage re-use you should consider making the objects available under an open [Creative Commons license](https://creativecommons.org/licenses/).
 
@@ -60,4 +60,3 @@ The following 4 rights statements are intended for works that are not in copyrig
 The following two rights statements are intended for use with digital objects where the copyright status has not been determined with certainty. These should only be used if it is not possible to use a clearer rights statement or license.
 
 {% include collection.html collection_id="http://rightsstatements.org/vocab/collection-other/1.0/" %}
-

--- a/js/app.js
+++ b/js/app.js
@@ -6,7 +6,7 @@
     // Randomize slider images in DOM to obviate patching
     // foundation library.
     var ul = $('ul[data-orbit]')[0];
-    for (var i = ul.children.length; i >= 0; i--) {
+    if (ul) for (var i = ul.children.length; i >= 0; i--) {
         ul.appendChild(ul.children[Math.random() * i | 0]);
     }
 

--- a/js/app.js
+++ b/js/app.js
@@ -1,12 +1,14 @@
 ---
 ---
-// Foundation JavaScript
-// Documentation can be found at: http://foundation.zurb.com/docs
-$(document).foundation();
-
-
 (function($) {
   $(document).ready(function() {
+
+    // Randomize slider images in DOM to obviate patching
+    // foundation library.
+    var ul = $('ul[data-orbit]')[0];
+    for (var i = ul.children.length; i >= 0; i--) {
+        ul.appendChild(ul.children[Math.random() * i | 0]);
+    }
 
     $('.milestone strong').appear(function() {
       $(this).countTo(100);
@@ -73,8 +75,12 @@ $(document).foundation();
     if ("http://rightsstatements.org".lastIndexOf(url) != 0) {
       $('body').children('div').first().prepend(
         $('<div data-alert class="alert-box warning row centered-text">You are seeing a preview of this page. To visit the currently published version, click <a href="http://rightsstatements.org' + location.pathname +'">here</a>.<a href="#" class="close">&times;</a></div>')
-      ).foundation();
+      );
     }
+
+    // Foundation JavaScript
+    // Documentation can be found at: http://foundation.zurb.com/docs
+    $(document).foundation();
 
   });
 })(jQuery);


### PR DESCRIPTION
On dev: http://h2481931.stratoserver.net:4000/

Fixes #45, #44, #43, #42, #41, #38, #35, #32, #26, #6.

Regarding #37, the logos are properly placed in a grid. They have very different image sizes, with e.g. the Europeana logo having much more empty space on top than the DPLA one. We should probably fix this by cropping the images accordingly.

Regarding #41, @j0hj0h adjusted the font sizes by rule of thumb because we did not receive any input on what the exact sizes should be.