### PR TITLE
Update vocab.md

### DIFF
--- a/et/statements/vocab.md
+++ b/et/statements/vocab.md
@@ -55,7 +55,7 @@ Järgmised viis autoriõigusliku seisundi deklaratsiooni on mõeldud kehtiva aut
 
 {% include collection.html collection_id="collection-ic" %}
 
-## Autoriõigusliku seisundi deklaratsioonid kehtiva autoriõigusega objektidele ## {#collection-nc}
+## Autoriõigusliku seisundi deklaratsioonid objektidele, millele ei kehti autoriõigus ## {#collection-nc}
 
 Järgmised neli autoriõigusliku seisundi deklaratsiooni on mõeldud selliste teoste märgistamiseks, millele ei kehti autoriõigus, kuid millele laienevad muud vaba taaskasutamist takistavad piirangud või mille autoriõigusliku kaitse puudumine on tuvastatud ainult mõne kindla õigusruumi puhul. Neid peaks kasutama ainult sellistel juhtudel, kus [avaliku omandi tähise](https://creativecommons.org/publicdomain/mark/1.0/) või [CC0 avaliku omandi märke](https://creativecommons.org/publicdomain/zero/1.0/) kasutamine ei ole võimalik.
 


### PR DESCRIPTION
Just discovered that the section title for ***Rights statements for objects that are not in copyright*** was in Estonian the same as for ***Rights statements for in copyright objects*** although in the official Estonian translation there is correct information that this title should be ***Autoriõigusliku seisundi deklaratsioonid objektidele, millele ei kehti autoriõigus***.